### PR TITLE
feat: MainMenu buttons color

### DIFF
--- a/src/3-organisms/MainMenu/MainMenu.tsx
+++ b/src/3-organisms/MainMenu/MainMenu.tsx
@@ -4,34 +4,48 @@ import {
     AppBar , Toolbar,  Divider, IconButton, withStyles 
   } from "@material-ui/core";
 import { People, Timeline ,Room } from "@material-ui/icons";
-import styles, { menuClasses } from "./styles";
+import styles, { iconClasses, menuClasses } from "./styles";
+import { useState } from "react";
 
 //********** Component **********//
 const MainMenu = (props: Props) => {
-    const {onIntersectionsButtonClick, onSignalersButtonClick, onTracksButtonClick} = props;
+    const {onIntersectionsButtonClick, onSignalersButtonClick, onTracksButtonClick } = props;
+    const [mode, setMode] = useState<"track"|"intersection"|"signaler">("track");
     return (
         <AppBar position="static" className={menuClasses(props)}>
             <Toolbar>
-                <IconButton
-                onClick={onTracksButtonClick}>
-                    <Timeline />
+                <IconButton 
+                    className={iconClasses(props,  mode==="track")}
+                    onClick={()=>{
+                        setMode("track");
+                        if(onTracksButtonClick)onTracksButtonClick();
+                    }}>
+                    <Timeline  />
                 </IconButton>
                 <Divider
                     orientation="vertical"
                     variant="fullWidth"
                     flexItem
                 />
-                <IconButton
-                onClick={onIntersectionsButtonClick}>
-                    <Room />
+                <IconButton 
+                    className={iconClasses(props, mode==="intersection")}
+                    onClick={()=>{
+                        setMode("intersection");
+                       if(onIntersectionsButtonClick)onIntersectionsButtonClick();
+                    }}>
+                    <Room/>
                 </IconButton>
                 <Divider
                     orientation="vertical"
                     variant="fullWidth"
                     flexItem
                 />
-                <IconButton
-                onClick={onSignalersButtonClick}>
+                <IconButton 
+                    className={iconClasses(props, mode==="signaler")}
+                    onClick={()=>{
+                        setMode("signaler");
+                        if(onSignalersButtonClick)onSignalersButtonClick();
+                    }}>
                     <People />
                 </IconButton>
             </Toolbar>

--- a/src/3-organisms/MainMenu/styles.ts
+++ b/src/3-organisms/MainMenu/styles.ts
@@ -1,6 +1,5 @@
 //********** Imports **********//
 import { Theme } from "@material-ui/core";
-import blueGrey from "@material-ui/core/colors/blueGrey";
 import { createStyles } from "@material-ui/core/styles";
 import clsx from "clsx";
 
@@ -11,11 +10,14 @@ const styles = (theme: Theme) =>
   createStyles<StylesKey, Props>({
     // Theme overrides
     root: {},
-    appBar:{
+    appBar: {
       borderRadius: "50px",
       width: "200px",
-      backgroundColor: blueGrey[100],
-  }
+      backgroundColor: theme.palette.background.paper,
+    },
+    iconSelected: {
+      color: theme.palette.primary.main,
+    }
   });
 
 export default styles;
@@ -27,4 +29,14 @@ export const menuClasses = (props: StylesProps) => {
 
   const { appBar, root } = classes;
   return clsx(appBar, root, className);
+};
+
+export const iconClasses = (props: StylesProps, selected:boolean) => {
+  const { classes, className } = props;
+  if (classes == null) return className;
+
+  const { iconSelected } = classes;
+  return clsx( className, {
+    [iconSelected]: selected,
+  });
 };

--- a/src/3-organisms/MainMenu/types.ts
+++ b/src/3-organisms/MainMenu/types.ts
@@ -26,6 +26,8 @@ export interface ThemeProps {};
 interface StylesClasses extends ThemeOverrides {
   /** Styles applied to the appBar. */
   appBar?:never;
+  /** Styles applied to the icon that is selected. */
+  iconSelected?:never;
 }
 export type StylesKey = keyof StylesClasses;
 export type ClassesProp = StyledComponentProps<StylesKey>["classes"];


### PR DESCRIPTION
The clicked/current button color is primary while other icons are uncolored.

https://www.notion.so/Permettre-au-menu-d-afficher-la-vue-courante-531d366ef1d140f99ee42c8f07f8a82a